### PR TITLE
use && to make the normal mouse buttons more responsive

### DIFF
--- a/SaneSideButtons/SwipeSimulator.swift
+++ b/SaneSideButtons/SwipeSimulator.swift
@@ -101,9 +101,7 @@ final class SwipeSimulator {
     }
 
     fileprivate func handleMouseEvent(type: CGEventType, cgEvent: CGEvent) -> CGEvent? {
-        let mouseDown = type == .otherMouseDown
-        let validApplication = self.isValidApplication()
-        guard mouseDown && validApplication else {
+        guard type == .otherMouseDown && self.isValidApplication() else {
             return cgEvent
         }
 


### PR DESCRIPTION
If the mouseEvent is not an .otherMouseDown, then we don't need to call NSWorkspace.shared.frontmostApplication?.bundleIdentifier making the first three mouse buttons slightly more responsive