### PR TITLE
Fix a mistake in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 	<img src="icon.png" width=150 />
 </p>
 
-macOS mostly ignores the M4/M5 mouse buttons, commonly used for navigation. Third-party apps can bind them to ⌘+[ and ⌘+], but this only works in a small number of apps and feels janky. With this tool, your side buttons will simulate 3-finger swipes, allowing you to navigate almost any window with a history. As seen in the Logitech MX Master!
+macOS mostly ignores the M4/M5 mouse buttons, commonly used for navigation. Third-party apps can bind them to ⌘+[ and ⌘+], but this only works in a small number of apps and feels janky. With this tool, your side buttons will simulate 2-finger swipes, allowing you to navigate almost any window with a history. As seen in the Logitech MX Master!
 
 ## About SaneSideButtons
 


### PR DESCRIPTION
Fixes "simulate 3-finger swipes" to "simulate 2-finger swipes". I know this was copied from SensibleSideButtons, but a 3-finger swipe left or right doesn't do anything related to navigation as far as I'm aware. Maybe this was always a typo?